### PR TITLE
ci(vercel): optimize cache control headers for static assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,34 @@
       ]
     },
     {
-      "source": "/**/*\\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)",
+      "source": "/(.*)\\.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.css",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(?:png|jpg|jpeg|gif|ico|svg)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(?:woff|woff2|ttf|eot)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Split the generic static assets rule into specific file type rules to ensure proper cache control headers are applied consistently